### PR TITLE
fix the @import-bug (btw: commits include the test-case)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+.idea/

--- a/README.md
+++ b/README.md
@@ -3,19 +3,41 @@ mcss loader for webpack
 
 ## Installation
 
-`npm install mcss-loader --save-dev`
+```bash
+npm install mcss-loader --save-dev
+````
 
 ## Usage
 
 ### webpack config
-
-``` javascript
+```javascript
 module.exports = {
   module: {
     loaders: [
       {
         test: /\.mcss$/,
         loader: "style!css!mcss"
+      }
+    ]
+  }
+};
+```
+
+Or add a config option via loader-query if necessary
+```javascript
+module.exports = {
+  module: {
+    loaders: [
+      {
+        test: /\.mcss$/,
+        loader: "style!css!mcss?" + JSON.stringify({
+                 format: 1,
+                 pathes:[
+                     './src/mcss'
+                 ],
+                 importCSS: false,
+                 indent: '\t'
+             })
       }
     ]
   }

--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
 
 var mcss = require('mcss'),
-  loaderUtils = require('loader-utils')
+  loaderUtils = require('loader-utils');
 
 module.exports = function(content) {
 	this.cacheable && this.cacheable();
 
 	var callback = this.async(),
-    options = loaderUtils.parseQuery(this.query)
-	
-	mcss(options).translate(content).done(function(text) {
+    options = loaderUtils.parseQuery(this.query);
+	options.filename = this.resource;//fix the path bug: @import string contain char like '../../'
+
+	mcss(options).translate().done(function(text) {//the param 'content' shouldn't be set in translate(content)
 		callback(null, text);
 	}).fail(function(err) {
 		callback(err);
 	});
-}
+};

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ module.exports = function(content) {
 	this.cacheable && this.cacheable();
 
 	var callback = this.async(),
-    options = loaderUtils.parseQuery(this.query);
+        options = loaderUtils.parseQuery(this.query);
+
 	options.filename = this.resource;//fix the path bug: @import string contain char like '../../'
 
 	mcss(options).translate().done(function(text) {//the param 'content' shouldn't be set in translate(content)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcss-loader",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "mcss loader for webpack",
   "main": "index.js",
   "keywords": [

--- a/test/dist.js
+++ b/test/dist.js
@@ -44,8 +44,11 @@
 /* 0 */
 /***/ function(module, exports, __webpack_require__) {
 
-	
-	__webpack_require__(1)
+	// normal
+	__webpack_require__(1);
+
+	// import abstract ./ ../  view detail in file './mcss/test2.mcss'
+	__webpack_require__(5);
 
 /***/ },
 /* 1 */
@@ -360,7 +363,6 @@
 	function applyToTag(styleElement, obj) {
 		var css = obj.css;
 		var media = obj.media;
-		var sourceMap = obj.sourceMap;
 
 		if(media) {
 			styleElement.setAttribute("media", media)
@@ -378,7 +380,6 @@
 
 	function updateLink(linkElement, obj) {
 		var css = obj.css;
-		var media = obj.media;
 		var sourceMap = obj.sourceMap;
 
 		if(sourceMap) {
@@ -395,6 +396,46 @@
 		if(oldSrc)
 			URL.revokeObjectURL(oldSrc);
 	}
+
+
+/***/ },
+/* 5 */
+/***/ function(module, exports, __webpack_require__) {
+
+	// style-loader: Adds some css to the DOM by adding a <style> tag
+
+	// load the styles
+	var content = __webpack_require__(6);
+	if(typeof content === 'string') content = [[module.id, content, '']];
+	// add the styles to the DOM
+	var update = __webpack_require__(4)(content, {});
+	if(content.locals) module.exports = content.locals;
+	// Hot Module Replacement
+	if(false) {
+		// When the styles change, update the <style> tags
+		if(!content.locals) {
+			module.hot.accept("!!./../../node_modules/css-loader/index.js?sourceMap!./../../index.js?sourceMap!./test2.mcss", function() {
+				var newContent = require("!!./../../node_modules/css-loader/index.js?sourceMap!./../../index.js?sourceMap!./test2.mcss");
+				if(typeof newContent === 'string') newContent = [[module.id, newContent, '']];
+				update(newContent);
+			});
+		}
+		// When the module is disposed, remove the <style> tags
+		module.hot.dispose(function() { update(); });
+	}
+
+/***/ },
+/* 6 */
+/***/ function(module, exports, __webpack_require__) {
+
+	exports = module.exports = __webpack_require__(3)();
+	// imports
+
+
+	// module
+	exports.push([module.id, ".u-outer{\n\tcolor:#000;\n}\n.u-inner{\n\tfont-size:12px;\n}\n.u-test2{\n\tcolor:#09c;\n}", "", {"version":3,"sources":["/./mcss/test2.mcss"],"names":[],"mappings":"AAAA;CACC,WAAW;CACX;AACD;CACC,eAAe;CACf;AACD;CACC,WAAW;CACX","file":"test2.mcss","sourcesContent":[".u-outer{\n\tcolor:#000;\n}\n.u-inner{\n\tfont-size:12px;\n}\n.u-test2{\n\tcolor:#09c;\n}"],"sourceRoot":"webpack://"}]);
+
+	// exports
 
 
 /***/ }

--- a/test/mcss/mixin.mcss
+++ b/test/mcss/mixin.mcss
@@ -1,0 +1,1 @@
+$colorDefinedInMixin ?= #09c;

--- a/test/mcss/subMcss/inner.mcss
+++ b/test/mcss/subMcss/inner.mcss
@@ -1,0 +1,3 @@
+.u-inner {
+  font-size: 12px;
+}

--- a/test/mcss/test2.mcss
+++ b/test/mcss/test2.mcss
@@ -1,0 +1,11 @@
+@import "../outer.mcss";
+
+@import "./subMcss/inner.mcss";
+// @import "subMcss/inner.mcss";
+
+@abstract "./mixin.mcss";
+// @abstract "mixin.mcss";
+
+.u-test2 {
+  color: $colorDefinedInMixin;
+}

--- a/test/outer.mcss
+++ b/test/outer.mcss
@@ -1,0 +1,3 @@
+.u-outer {
+  color: black;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,2 +1,5 @@
+// normal
+require('./index.mcss');
 
-require('./index.mcss')
+// import abstract ./ ../  view detail in file './mcss/test2.mcss'
+require('./mcss/test2.mcss');

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -9,6 +9,16 @@ module.exports = {
         loaders: [{
             test: /\.mcss$/,
             loader: 'style-loader!css-loader?sourceMap!../index.js?sourceMap'
+            // loader: 'style-loader!css-loader?sourceMap!../index.js?'+JSON.stringify({
+            //     format: 1,
+            //     pathes:[
+            //         './mcss',
+            //         './mcss/subMcss'
+            //     ],
+            //     importCSS: false,
+            //     indent: '\t',
+            //     sourceMap: 1
+            // })
         }]
     }
-}
+};


### PR DESCRIPTION
## It reports 'not found error' during packing when file include import path like '../../xxx'.mcss or './xxx.mcss'
#### webpack config loader

``` js
loaders:[
    {
        test: /\.mcss$/,
        loader: ExtractTextPlugin.extract('style','css!mcss?' +
               JSON.stringify({
                        format: 1,
                        pathes:[
                              // path.join(__dirname,"./src/mcss")
                             './src/mcss'
                        ]
               })
         )
    },
    //...
]
```
#### index.js

``` js
require("A.mcss");
```
#### A.mcss

``` css
@import "../B.mcss"; // '../xxx.mcss' the parents director
@import "./C.mcss";  //'./xxx.mcss' current director
```

And two files ‘B.mcss & C.mcss’ are actually  existed
#### Reports:

```
 Module build failed: SyntaxError: ../B.mcss FILE NOT FOUND
 Module build failed: SyntaxError: ./C.mcss FILE NOT FOUND
```
