### PR TITLE
add include option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,32 @@
-
-var mcss = require('mcss'),
-  loaderUtils = require('loader-utils');
+var path = require('path');
+var mcss = require('mcss');
+var loaderUtils = require('loader-utils');
 
 module.exports = function(content) {
-	this.cacheable && this.cacheable();
+    this.cacheable && this.cacheable();
 
-	var callback = this.async(),
-        options = loaderUtils.parseQuery(this.query);
+    var callback = this.async();
+    var options = loaderUtils.parseQuery(this.query);
 
-	options.filename = this.resource;//fix the path bug: @import string contain char like '../../'
+    options.filename = this.resource; //fix the path bug: @import string contain char like '../../'
 
-	mcss(options).translate().done(function(text) {//the param 'content' shouldn't be set in translate(content)
-		callback(null, text);
-	}).fail(function(err) {
-		callback(err);
-	});
+    var include;
+    var cwd = process.cwd();
+
+    if (options.include) {
+        if (!Array.isArray(options.include)) { options.include = [ options.include ]; }
+        include = options.include.map(function (p) {
+            return path.resolve(cwd, p);
+        });
+    }
+
+    var instance = mcss(options);
+
+    if (include) { instance.include(include); }
+
+    instance.translate().done(function(text) {//the param 'content' shouldn't be set in translate(content)
+        callback(null, text);
+    }).fail(function(err) {
+        callback(err);
+    });
 };

--- a/test/dist.js
+++ b/test/dist.js
@@ -66,8 +66,8 @@
 	if(false) {
 		// When the styles change, update the <style> tags
 		if(!content.locals) {
-			module.hot.accept("!!./../node_modules/css-loader/index.js?sourceMap!./../index.js?sourceMap!./index.mcss", function() {
-				var newContent = require("!!./../node_modules/css-loader/index.js?sourceMap!./../index.js?sourceMap!./index.mcss");
+			module.hot.accept("!!./../node_modules/css-loader/index.js?sourceMap!./../index.js?include=./include!./index.mcss", function() {
+				var newContent = require("!!./../node_modules/css-loader/index.js?sourceMap!./../index.js?include=./include!./index.mcss");
 				if(typeof newContent === 'string') newContent = [[module.id, newContent, '']];
 				update(newContent);
 			});
@@ -85,7 +85,7 @@
 
 
 	// module
-	exports.push([module.id, ".title{\n\tcolor:#ccc;\n}\n.title a{\n\tcolor:#000;\n}\n.title a:hover{\n\tcolor:#666;\n}", "", {"version":3,"sources":["/./index.mcss"],"names":[],"mappings":"AAAA;CACC,WAAW;CACX;AACD;CACC,WAAW;CACX;AACD;CACC,WAAW;CACX","file":"index.mcss","sourcesContent":[".title{\n\tcolor:#ccc;\n}\n.title a{\n\tcolor:#000;\n}\n.title a:hover{\n\tcolor:#666;\n}"],"sourceRoot":"webpack://"}]);
+	exports.push([module.id, ".title{\n\tcolor:#ccc;\n}\n.title a{\n\tcolor:#000;\n}\n.title a:hover{\n\tcolor:#666;\n}\n.cube{\n\twidth:100px;\n\theight:100px;\n\tline-height:100px;\n\ttext-align:center;\n\tcolor:#333;\n\tbackground-color:#f1f1f1;\n}", "", {"version":3,"sources":["/./index.mcss"],"names":[],"mappings":"AAAA;CACC,WAAW;CACX;AACD;CACC,WAAW;CACX;AACD;CACC,WAAW;CACX;AACD;CACC,YAAY;CACZ,aAAa;CACb,kBAAkB;CAClB,kBAAkB;CAClB,WAAW;CACX,yBAAyB;CACzB","file":"index.mcss","sourcesContent":[".title{\n\tcolor:#ccc;\n}\n.title a{\n\tcolor:#000;\n}\n.title a:hover{\n\tcolor:#666;\n}\n.cube{\n\twidth:100px;\n\theight:100px;\n\tline-height:100px;\n\ttext-align:center;\n\tcolor:#333;\n\tbackground-color:#f1f1f1;\n}"],"sourceRoot":"webpack://"}]);
 
 	// exports
 
@@ -414,8 +414,8 @@
 	if(false) {
 		// When the styles change, update the <style> tags
 		if(!content.locals) {
-			module.hot.accept("!!./../../node_modules/css-loader/index.js?sourceMap!./../../index.js?sourceMap!./test2.mcss", function() {
-				var newContent = require("!!./../../node_modules/css-loader/index.js?sourceMap!./../../index.js?sourceMap!./test2.mcss");
+			module.hot.accept("!!./../../node_modules/css-loader/index.js?sourceMap!./../../index.js?include=./include!./test2.mcss", function() {
+				var newContent = require("!!./../../node_modules/css-loader/index.js?sourceMap!./../../index.js?include=./include!./test2.mcss");
 				if(typeof newContent === 'string') newContent = [[module.id, newContent, '']];
 				update(newContent);
 			});

--- a/test/include/mixin.mcss
+++ b/test/include/mixin.mcss
@@ -1,0 +1,4 @@
+$cube = ($size = 0) {
+    width: $size;
+    height: $size;
+}

--- a/test/index.html
+++ b/test/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
 <div class="title">一个链接: <a href="www.sohu.com">sohu</a></div>
+<div class="cube">I'm a CUBE</div>
 <script src="dist.js"></script>
 </body>
 </html>

--- a/test/index.mcss
+++ b/test/index.mcss
@@ -1,3 +1,4 @@
+@import "mixin.mcss";
 
 .title {
 	color: #ccc;
@@ -9,4 +10,12 @@
 			color: #666;
 		}
 	}
+}
+
+.cube {
+	$cube(100px);
+	line-height: 100px;
+	text-align: center;
+	color: #333;
+	background-color: #f1f1f1;
 }

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     module: {
         loaders: [{
             test: /\.mcss$/,
-            loader: 'style-loader!css-loader?sourceMap!../index.js?sourceMap'
+            loader: 'style-loader!css-loader?sourceMap!../index.js?include=./include'
             // loader: 'style-loader!css-loader?sourceMap!../index.js?'+JSON.stringify({
             //     format: 1,
             //     pathes:[


### PR DESCRIPTION
there's a file in "/some/where/index.mcss"
a mcss file in "/some/libs/a/mixin.mcss"

pass a include option through query
{ test: /\.mcss$/, loader: "mcss-loader?include=/some/libs" }

then
in /"some/where/index.mcss" we can
@import ''a/mixin.mcss";
// instead of @import ''../libs/a/mixin.mcss"